### PR TITLE
Refine builder constructor layout with SVG sprite

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -34,16 +34,30 @@
       <section class="section">
         <div class="container builder-layout">
           <div class="builder-preview">
-            <h1>Соберите котика из деталей корзины</h1>
-            <p class="text-muted">
+            <figure class="builder-stage" role="img" aria-label="Превью котика">
+              <div class="builder-stage__frame">
+                <svg class="builder-canvas" viewBox="0 0 140 160" aria-hidden="true">
+                  <g class="builder-tail" transform="translate(12,72)">
+                    <use id="builder-tail" href="images/cats-sprite.svg#tail-1" class="sketch"></use>
+                  </g>
+                  <g class="builder-body" transform="translate(8,72)">
+                    <use id="builder-body" href="images/cats-sprite.svg#body-1" class="sketch"></use>
+                    <use id="builder-pattern" href="images/cats-sprite.svg#stripes" class="sketch"></use>
+                  </g>
+                  <g class="builder-face" transform="translate(20,12)">
+                    <use id="builder-head" href="images/cats-sprite.svg#head-1" class="sketch"></use>
+                    <use id="builder-eyes" href="images/cats-sprite.svg#eyes-1" class="sketch"></use>
+                    <use id="builder-muzzle" href="images/cats-sprite.svg#muzzle-1" class="sketch"></use>
+                    <use id="builder-whiskers" href="images/cats-sprite.svg#whisk-1" class="sketch"></use>
+                  </g>
+                </svg>
+              </div>
+            </figure>
+            <h1 class="builder-title">Соберите котика из деталей корзины</h1>
+            <p class="builder-description text-muted">
               Выбранные части синхронизируются с корзиной. Меняйте мордочки, хвосты и эффекты — изображение
               котика обновится мгновенно.
             </p>
-            <div class="builder-stage" role="img" aria-label="Превью котика">
-              <img id="builder-body" src="images/builder-body-cream.svg" alt="Тело котика" />
-              <img id="builder-face" src="images/builder-face-smile.svg" alt="Мордочка котика" />
-              <img id="builder-tail" src="images/builder-tail-classic.svg" alt="Хвост котика" />
-            </div>
           </div>
 
           <form class="builder-controls" aria-label="Доступные детали из корзины">

--- a/images/cats-sprite.svg
+++ b/images/cats-sprite.svg
@@ -1,0 +1,86 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="0" height="0" style="position:absolute">
+  <defs>
+    <style>
+      .sketch{fill:none;stroke:currentColor;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;vector-effect:non-scaling-stroke}
+    </style>
+
+    <!-- HEADS (viewBox 0 0 100 100) -->
+    <symbol id="head-1" viewBox="0 0 100 100">
+      <path class="sketch" d="M20 40 Q18 25 30 20 L40 28 L50 22 L60 28 L70 20 Q82 25 80 40
+                               Q82 70 50 78 Q18 70 20 40 Z"/>
+    </symbol>
+    <symbol id="head-2" viewBox="0 0 100 100">
+      <path class="sketch" d="M18 44 Q25 18 50 18 Q75 18 82 44 Q85 70 50 82 Q15 70 18 44 Z"/>
+      <path class="sketch" d="M32 24 40 16 48 26M68 24 60 16 52 26"/>
+    </symbol>
+    <symbol id="head-3" viewBox="0 0 100 100">
+      <ellipse class="sketch" cx="50" cy="50" rx="32" ry="28"/>
+      <path class="sketch" d="M30 27 40 20 45 32M70 27 60 20 55 32"/>
+    </symbol>
+
+    <!-- EYES -->
+    <symbol id="eyes-1" viewBox="0 0 100 100">
+      <path class="sketch" d="M34 48 q4 -4 8 0M58 48 q4 -4 8 0"/>
+    </symbol>
+    <symbol id="eyes-2" viewBox="0 0 100 100">
+      <circle class="sketch" cx="38" cy="50" r="3"/>
+      <circle class="sketch" cx="62" cy="50" r="3"/>
+    </symbol>
+    <symbol id="eyes-3" viewBox="0 0 100 100">
+      <path class="sketch" d="M33 49 q5 -6 10 0M57 49 q5 -6 10 0M36 50 l4 0M60 50 l4 0"/>
+    </symbol>
+
+    <!-- NOSE + MOUTH -->
+    <symbol id="muzzle-1" viewBox="0 0 100 100">
+      <path class="sketch" d="M48 56 l4 0M50 56 v4"/>
+      <path class="sketch" d="M50 60 q-6 6 -12 0M50 60 q6 6 12 0"/>
+    </symbol>
+    <symbol id="muzzle-2" viewBox="0 0 100 100">
+      <path class="sketch" d="M47 55 l6 0M50 55 v6"/>
+      <path class="sketch" d="M38 62 q5 6 14 0 q5 6 10 0"/>
+    </symbol>
+
+    <!-- WHISKERS -->
+    <symbol id="whisk-1" viewBox="0 0 100 100">
+      <path class="sketch" d="M18 58 l22 -4M18 64 l22 0M18 70 l22 4M82 58 l-22 -4M82 64 l-22 0M82 70 l-22 4"/>
+    </symbol>
+    <symbol id="whisk-2" viewBox="0 0 100 100">
+      <path class="sketch" d="M16 62 l24 -2M16 66 l24 2M84 62 l-24 -2M84 66 l-24 2"/>
+    </symbol>
+
+    <!-- BODIES -->
+    <symbol id="body-1" viewBox="0 0 120 100">
+      <path class="sketch" d="M20 60 q15 -22 40 -22 q25 0 40 22 q2 20 -40 20 q-42 0 -40 -20 Z"/>
+      <path class="sketch" d="M36 80 q4 10 10 12M84 80 q-4 10 -10 12"/>
+    </symbol>
+    <symbol id="body-2" viewBox="0 0 120 100">
+      <path class="sketch" d="M24 64 q12 -26 36 -26 q24 0 36 26 q2 18 -36 18 q-38 0 -36 -18 Z"/>
+      <path class="sketch" d="M54 70 q-6 8 0 16 q6 -8 0 -16Z"/>
+    </symbol>
+    <symbol id="body-3" viewBox="0 0 120 100">
+      <ellipse class="sketch" cx="60" cy="70" rx="42" ry="20"/>
+      <path class="sketch" d="M30 78 q6 8 12 10M90 78 q-6 8 -12 10"/>
+    </symbol>
+
+    <!-- TAILS -->
+    <symbol id="tail-1" viewBox="0 0 120 100">
+      <path class="sketch" d="M98 66 q14 -6 12 -18 q-2 -12 -18 -10 q-10 2 -12 8"/>
+    </symbol>
+    <symbol id="tail-2" viewBox="0 0 120 100">
+      <path class="sketch" d="M100 68 q18 0 12 16 q-6 14 -26 8 q-10 -4 -10 -12"/>
+    </symbol>
+    <symbol id="tail-3" viewBox="0 0 120 100">
+      <path class="sketch" d="M96 64 q10 -12 0 -22 q-10 -10 -24 0 q-8 6 -6 12"/>
+    </symbol>
+
+    <!-- PATTERNS -->
+    <symbol id="stripes" viewBox="0 0 120 100">
+      <path class="sketch" d="M44 56 l-8 8M56 52 l-8 8M68 52 l-8 8M80 56 l-8 8"/>
+    </symbol>
+    <symbol id="spots" viewBox="0 0 120 100">
+      <circle class="sketch" cx="48" cy="64" r="4"/>
+      <circle class="sketch" cx="68" cy="72" r="5"/>
+      <circle class="sketch" cx="58" cy="80" r="3"/>
+    </symbol>
+  </defs>
+</svg>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -106,25 +106,42 @@ const builderControls = document.querySelector('.builder-controls');
 if (builderControls) {
   const builderAssets = {
     body: {
-      cream: 'images/builder-body-cream.svg',
-      violet: 'images/builder-body-violet.svg',
-      mint: 'images/builder-body-mint.svg',
+      cream: { body: '#body-1', pattern: '#stripes' },
+      violet: { body: '#body-2', pattern: '#spots' },
+      mint: { body: '#body-3', pattern: null },
     },
     face: {
-      smile: 'images/builder-face-smile.svg',
-      dream: 'images/builder-face-dream.svg',
-      pixel: 'images/builder-face-pixel.svg',
+      smile: { head: '#head-1', eyes: '#eyes-1', muzzle: '#muzzle-1', whiskers: '#whisk-1' },
+      dream: { head: '#head-2', eyes: '#eyes-2', muzzle: '#muzzle-2', whiskers: '#whisk-2' },
+      pixel: { head: '#head-3', eyes: '#eyes-3', muzzle: '#muzzle-1', whiskers: '#whisk-1' },
     },
     tail: {
-      classic: 'images/builder-tail-classic.svg',
-      flare: 'images/builder-tail-flare.svg',
-      soft: 'images/builder-tail-soft.svg',
+      classic: '#tail-1',
+      flare: '#tail-2',
+      soft: '#tail-3',
     },
   };
 
-  const bodyImg = document.getElementById('builder-body');
-  const faceImg = document.getElementById('builder-face');
-  const tailImg = document.getElementById('builder-tail');
+  const spritePath = 'images/cats-sprite.svg';
+
+  const bodyUse = document.getElementById('builder-body');
+  const patternUse = document.getElementById('builder-pattern');
+  const headUse = document.getElementById('builder-head');
+  const eyesUse = document.getElementById('builder-eyes');
+  const muzzleUse = document.getElementById('builder-muzzle');
+  const whiskersUse = document.getElementById('builder-whiskers');
+  const tailUse = document.getElementById('builder-tail');
+
+  const setUseHref = (element, symbolId) => {
+    if (!element) return;
+    if (symbolId) {
+      element.setAttribute('href', `${spritePath}${symbolId}`);
+      element.style.display = '';
+    } else {
+      element.removeAttribute('href');
+      element.style.display = 'none';
+    }
+  };
 
   builderControls.addEventListener('change', (event) => {
     const target = event.target;
@@ -137,18 +154,24 @@ if (builderControls) {
 
     switch (part) {
       case 'body':
-        if (bodyImg && builderAssets.body[value]) {
-          bodyImg.src = builderAssets.body[value];
+        if (builderAssets.body[value]) {
+          const { body, pattern } = builderAssets.body[value];
+          setUseHref(bodyUse, body);
+          setUseHref(patternUse, pattern);
         }
         break;
       case 'face':
-        if (faceImg && builderAssets.face[value]) {
-          faceImg.src = builderAssets.face[value];
+        if (builderAssets.face[value]) {
+          const { head, eyes, muzzle, whiskers } = builderAssets.face[value];
+          setUseHref(headUse, head);
+          setUseHref(eyesUse, eyes);
+          setUseHref(muzzleUse, muzzle);
+          setUseHref(whiskersUse, whiskers);
         }
         break;
       case 'tail':
-        if (tailImg && builderAssets.tail[value]) {
-          tailImg.src = builderAssets.tail[value];
+        if (builderAssets.tail[value]) {
+          setUseHref(tailUse, builderAssets.tail[value]);
         }
         break;
       default:

--- a/styles/main.css
+++ b/styles/main.css
@@ -198,22 +198,23 @@ body::after {
   display: grid;
   align-items: center;
   grid-template-columns: max-content 1fr max-content;
-  gap: 32px;
+  gap: 24px;
 }
 
 .app-header__nav {
   display: flex;
   align-items: center;
-  gap: 18px;
+  gap: 14px;
 }
 
 .app-header__link {
   font-weight: 700;
-  padding: 10px 20px;
+  padding: 8px 16px;
   border-radius: 999px;
   border: 2px dashed transparent;
   transition: color 0.2s ease, transform 0.2s var(--transition-snap);
   font-family: var(--font-hand);
+  font-size: 0.95rem;
 }
 
 .app-header__link:hover,
@@ -230,7 +231,7 @@ body::after {
 .app-header__actions {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 10px;
 }
 
 .secondary-btn--active,
@@ -703,6 +704,7 @@ body::after {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 360px);
   gap: 40px;
+  align-items: start;
 }
 
 .builder-preview {
@@ -710,22 +712,39 @@ body::after {
   gap: 18px;
 }
 
+.builder-title {
+  font-size: clamp(2rem, 1.6vw + 1.6rem, 2.5rem);
+  line-height: 1.15;
+}
+
+.builder-description {
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
 .builder-stage {
-  position: relative;
   width: min(420px, 100%);
+  margin: 0;
+  display: grid;
+  justify-items: center;
+}
+
+.builder-stage__frame {
+  width: 100%;
   aspect-ratio: 1 / 1;
-  margin-top: 12px;
   background: rgba(255, 247, 229, 0.8);
   border-radius: var(--radius-lg);
   border: 3px solid var(--border-strong);
   box-shadow: var(--shadow-md);
   display: grid;
   place-items: center;
+  padding: 18px;
 }
 
-.builder-stage img {
-  position: absolute;
-  width: 90%;
+.builder-canvas {
+  width: 100%;
+  height: auto;
+  color: var(--text);
 }
 
 .builder-controls {
@@ -818,8 +837,8 @@ body::after {
     width: 100%;
   }
 
-  .builder-stage img {
-    width: 80%;
+  .builder-stage__frame {
+    padding: 12px;
   }
 
   .catalog-sidebar {
@@ -993,10 +1012,11 @@ header .header-inner {
   gap: 14px;
   background: var(--panel);
   border-radius: 999px;
-  padding: 12px 24px;
+  padding: 10px 18px;
   border: 3px solid var(--border);
   box-shadow: var(--shadow-sm);
   color: var(--border-strong);
+  width: clamp(180px, 22vw, 240px);
 }
 
 .search-bar input {


### PR DESCRIPTION
## Summary
- replace the builder preview with an inline SVG assembly that references a shared cat sprite
- add the cats sprite asset and update builder controls JS to swap symbol references instead of image files
- tighten header spacing and builder typography so the navigation fits without clipping on standard zoom

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e40bd8383483209f56d30408ed03be