### PR TITLE
Remove focus shadow from search bar input

### DIFF
--- a/front/assets/css/main.css
+++ b/front/assets/css/main.css
@@ -1128,6 +1128,10 @@ header .header-inner {
   color: var(--text);
 }
 
+.search-bar input:focus {
+  box-shadow: none;
+}
+
 .nav-actions {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- override the search bar input focus state to eliminate the red glow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908920d3910832089e4c242dc31aa51