### PR TITLE
Use SVG assets for cat builder

### DIFF
--- a/front/assets/css/main.css
+++ b/front/assets/css/main.css
@@ -765,20 +765,22 @@ body::after {
   font-weight: 800;
 }
 
-.builder-layout {
+.builder-shell {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 360px);
-  gap: 40px;
-  align-items: start;
+  gap: 28px;
+  align-items: center;
 }
 
-.builder-preview {
+.builder-intro {
   display: grid;
-  gap: 18px;
+  gap: 10px;
+  text-align: center;
+  max-width: 760px;
+  margin: 0 auto;
 }
 
 .builder-title {
-  font-size: clamp(2rem, 1.6vw + 1.6rem, 2.5rem);
+  font-size: clamp(2rem, 1.6vw + 1.6rem, 2.6rem);
   line-height: 1.15;
 }
 
@@ -787,104 +789,100 @@ body::after {
   line-height: 1.6;
 }
 
-.builder-stage {
-  width: min(420px, 100%);
-  margin: 0;
-  display: grid;
-  justify-items: center;
-}
-
-.builder-stage__frame {
-  width: 100%;
-  aspect-ratio: 1 / 1;
-  background: rgba(255, 247, 229, 0.8);
+.cat-builder {
+  background: var(--panel);
   border-radius: var(--radius-lg);
   border: 3px solid var(--border-strong);
   box-shadow: var(--shadow-md);
+  padding: clamp(18px, 3vw, 28px);
+  display: grid;
+  gap: 18px;
+  justify-items: center;
+}
+
+.cat-stage {
+  position: relative;
+  width: min(520px, 96vw);
+  aspect-ratio: 3 / 4;
+  background: linear-gradient(180deg, #fff7e5 0%, #fffaf2 50%, #f7fbff 100%);
+  border-radius: var(--radius-lg);
+  border: 3px solid var(--border-strong);
+  box-shadow: var(--shadow-md);
+  overflow: hidden;
+}
+
+.cat-canvas {
+  position: absolute;
+  inset: 0;
   display: grid;
   place-items: center;
-  padding: 18px;
 }
 
-.builder-canvas {
-  width: 100%;
-  height: auto;
+.cat-layer {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  user-select: none;
+  pointer-events: none;
+}
+
+.cat-body {
+  width: 68%;
+  bottom: 8%;
+}
+
+.cat-head {
+  width: 52%;
+  top: 14%;
+  z-index: 2;
+}
+
+.arrow-btn {
+  position: absolute;
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  border: 3px solid var(--border-strong);
+  background: #fff;
   color: var(--text);
-}
-
-.builder-controls {
-  display: grid;
-  gap: 24px;
-}
-
-.builder-group {
-  display: grid;
-  gap: 10px;
-  background: var(--panel);
-  border-radius: var(--radius-md);
-  border: 3px solid var(--border-strong);
-  padding: 20px;
-  box-shadow: var(--shadow-sm);
-}
-
-.builder-group legend {
+  font-size: 1.4rem;
   font-weight: 800;
-  margin-bottom: 10px;
-  font-family: var(--font-hand);
-  font-size: 1.2rem;
-}
-
-.builder-group label {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  font-size: 0.95rem;
-}
-
-.builder-group input[type="radio"],
-.builder-group input[type="checkbox"] {
-    appearance: none;
-    width: 16px;
-    height: 16px;
-    border: 2px solid #333;
-    border-radius: 16px;
-    display: inline-block;
-    position: relative;
-    background-color: #fff;
-    transition: all 0.15s ease-in-out;
-    box-shadow: 0 1px 2px rgba(0,0,0,0.2);
-}
-
-.builder-group input[type="checkbox"]:hover,
-.builder-group input[type="radio"]:hover {
-    border-color: #cc9933;
-}
-
-.builder-group input[type="checkbox"]:checked,
-.builder-group input[type="radio"]:checked {
-    background-color: #ffcc66;
-    border-color: #cc9933;
-    box-shadow: 0 0 3px rgba(204, 153, 51, 0.6);
-}
-
-.builder-group input[type="checkbox"]:checked::after,
-.builder-group input[type="radio"]:checked::after {
-    content: "✔";
-    font-size: 18px;
-    color: #333;
-    position: absolute;
-    top: 0;
-    left: 10px;
-}
-
-.builder-summary {
-  background: var(--panel);
-  border-radius: var(--radius-md);
-  border: 3px solid var(--border-strong);
-  padding: 24px;
-  display: grid;
-  gap: 12px;
   box-shadow: var(--shadow-sm);
+  display: grid;
+  place-items: center;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+}
+
+.arrow-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+  background: #fff3d7;
+}
+
+.arrow-btn--left {
+  left: 6%;
+}
+
+.arrow-btn--right {
+  right: 6%;
+}
+
+.head-arrow {
+  top: 16%;
+}
+
+.body-arrow {
+  bottom: 32%;
+}
+
+.builder-note {
+  background: rgba(255, 247, 229, 0.7);
+  border-radius: var(--radius-md);
+  border: 2px dashed var(--border);
+  padding: 14px 18px;
+  color: var(--text-muted);
+  text-align: center;
+  width: 100%;
 }
 
 .small-message {
@@ -901,7 +899,6 @@ body::after {
 @media (max-width: 1024px) {
   .catalog-layout,
   .profile-layout,
-  .builder-layout,
   .box-card {
     grid-template-columns: 1fr;
   }
@@ -934,12 +931,8 @@ body::after {
     text-align: center;
   }
 
-  .builder-stage {
+  .cat-stage {
     width: 100%;
-  }
-
-  .builder-stage__frame {
-    padding: 12px;
   }
 
   .catalog-sidebar {

--- a/front/components/builder.html
+++ b/front/components/builder.html
@@ -32,96 +32,99 @@
 
     <main>
       <section class="section">
-        <div class="container builder-layout">
-          <div class="builder-preview">
-            <figure class="builder-stage" role="img" aria-label="Превью котика">
-              <div class="builder-stage__frame">
-                <svg class="builder-canvas" viewBox="0 0 140 160" aria-hidden="true">
-                  <g class="builder-tail" transform="translate(12,72)">
-                    <use id="builder-tail" href="images/cats-sprite.svg#tail-1" class="sketch"></use>
-                  </g>
-                  <g class="builder-body" transform="translate(8,72)">
-                    <use id="builder-body" href="images/cats-sprite.svg#body-1" class="sketch"></use>
-                    <use id="builder-pattern" href="images/cats-sprite.svg#stripes" class="sketch"></use>
-                  </g>
-                  <g class="builder-face" transform="translate(20,12)">
-                    <use id="builder-head" href="images/cats-sprite.svg#head-1" class="sketch"></use>
-                    <use id="builder-eyes" href="images/cats-sprite.svg#eyes-1" class="sketch"></use>
-                    <use id="builder-muzzle" href="images/cats-sprite.svg#muzzle-1" class="sketch"></use>
-                    <use id="builder-whiskers" href="images/cats-sprite.svg#whisk-1" class="sketch"></use>
-                    <image
-                      id="builder-face-legend"
-                      data-face-image="legend"
-                      href="images/builder-face-legend.svg"
-                      width="100"
-                      height="100"
-                      preserveAspectRatio="xMidYMid meet"
-                      style="display: none"
-                    ></image>
-                  </g>
-                </svg>
-              </div>
-            </figure>
-            <h1 class="builder-title">Соберите котика из деталей корзины</h1>
+        <div class="container builder-shell">
+          <div class="builder-intro">
+            <h1 class="builder-title">Соберите котика из любимых деталей</h1>
             <p class="builder-description text-muted">
-              Выбранные части синхронизируются с корзиной. Меняйте мордочки, хвосты и эффекты — изображение
-              котика обновится мгновенно.
+              Переключайте голову и тело стрелками, чтобы моментально увидеть новые сочетания. Навигация сверху остаётся
+              нетронутой — экспериментируйте с образами прямо здесь, без перезагрузок.
             </p>
           </div>
 
-          <form class="builder-controls" aria-label="Доступные детали из корзины">
-            <fieldset class="builder-group" data-part="body">
-              <legend>Базовое тело</legend>
-              <label>
-                <input type="radio" name="body" value="cream" checked /> Кремовый — базовый комплект
-              </label>
-              <label>
-                <input type="radio" name="body" value="violet" /> Фиолетовый — сезон «Комета»
-              </label>
-              <label>
-                <input type="radio" name="body" value="mint" /> Мятный — бокс «Crystal»
-              </label>
-            </fieldset>
+          <div class="cat-builder" aria-label="Интерактивный конструктор котика">
+            <div class="cat-stage" role="img" aria-label="Визуальный предпросмотр котика">
+              <button class="arrow-btn head-arrow arrow-btn--left" type="button" onclick="prevHead()" aria-label="Предыдущая голова">
+                &#8249;
+              </button>
+              <button class="arrow-btn head-arrow arrow-btn--right" type="button" onclick="nextHead()" aria-label="Следующая голова">
+                &#8250;
+              </button>
 
-            <fieldset class="builder-group" data-part="face">
-              <legend>Мордочки</legend>
-              <label>
-                <input type="radio" name="face" value="smile" checked /> Mint Smile из корзины
-              </label>
-              <label>
-                <input type="radio" name="face" value="dream" /> Dreamy Eyes из набора Aurora
-              </label>
-              <label>
-                <input type="radio" name="face" value="pixel" /> Pixel Wink из ретро-пака
-              </label>
-              <label>
-                <input type="radio" name="face" value="legend" /> Легендарная мордочка из архива
-              </label>
-            </fieldset>
+              <button class="arrow-btn body-arrow arrow-btn--left" type="button" onclick="prevBody()" aria-label="Предыдущее тело">
+                &#8249;
+              </button>
+              <button class="arrow-btn body-arrow arrow-btn--right" type="button" onclick="nextBody()" aria-label="Следующее тело">
+                &#8250;
+              </button>
 
-            <fieldset class="builder-group" data-part="tail">
-              <legend>Хвосты</legend>
-              <label>
-                <input type="radio" name="tail" value="classic" checked /> Crystal Tail — корзина
-              </label>
-              <label>
-                <input type="radio" name="tail" value="flare" /> Storm Flare — бокс «Гроза»
-              </label>
-              <label>
-                <input type="radio" name="tail" value="soft" /> Velvet Soft — витрина Meowcore
-              </label>
-            </fieldset>
-
-            <div class="builder-summary">
-              <h2>Итоговая сборка</h2>
-              <p class="text-muted">Все изменения сохраняются в корзине и доступны в заказах после покупки.</p>
-              <button class="primary-btn" type="submit">Сохранить пресет</button>
+              <div class="cat-canvas">
+                <img
+                  id="cat-body"
+                  class="cat-layer cat-body"
+                  src="../assets/images/builder-body-cream.svg"
+                  alt="Тело котика"
+                />
+                <img
+                  id="cat-head"
+                  class="cat-layer cat-head"
+                  src="../assets/images/builder-face-pixel.svg"
+                  alt="Голова котика"
+                />
+              </div>
             </div>
-          </form>
+
+            <div class="builder-note">
+              <p>Подбирайте сочетания, пока котик не станет идеальным. Готовые пресеты сохранятся при переходе в каталог.</p>
+            </div>
+          </div>
         </div>
       </section>
     </main>
 
     <script src="../assets/java/main.js"></script>
+    <script>
+      const heads = [
+        "../assets/images/builder-face-pixel.svg",
+        "../assets/images/builder-face-dream.svg",
+        "../assets/images/builder-face-smile.svg",
+        "../assets/images/builder-face-legend.svg",
+      ];
+      const bodies = [
+        "../assets/images/builder-body-cream.svg",
+        "../assets/images/builder-body-mint.svg",
+        "../assets/images/builder-body-violet.svg",
+      ];
+
+      let headIndex = 0;
+      let bodyIndex = 0;
+
+      function updateHead() {
+        document.getElementById("cat-head").src = heads[headIndex];
+      }
+
+      function updateBody() {
+        document.getElementById("cat-body").src = bodies[bodyIndex];
+      }
+
+      function nextHead() {
+        headIndex = (headIndex + 1) % heads.length;
+        updateHead();
+      }
+
+      function prevHead() {
+        headIndex = (headIndex - 1 + heads.length) % heads.length;
+        updateHead();
+      }
+
+      function nextBody() {
+        bodyIndex = (bodyIndex + 1) % bodies.length;
+        updateBody();
+      }
+
+      function prevBody() {
+        bodyIndex = (bodyIndex - 1 + bodies.length) % bodies.length;
+        updateBody();
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- swap cat builder head/body variant arrays to use existing SVG assets
- remove the added PNG layer files from the builder assets

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69271602e5f88320b948181eaff12491)